### PR TITLE
Wind flag refactor

### DIFF
--- a/common/src/main/java/com/quintonc/vs_sails/blocks/CountableBlock.java
+++ b/common/src/main/java/com/quintonc/vs_sails/blocks/CountableBlock.java
@@ -19,6 +19,7 @@ import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3d;
+import org.joml.Vector3dc;
 import org.valkyrienskies.core.api.VsCoreApi;
 import org.valkyrienskies.core.api.event.EventConsumer;
 import org.valkyrienskies.core.api.event.RegisteredListener;
@@ -86,12 +87,12 @@ public abstract class CountableBlock extends Block implements ICopyableBlock {
     abstract void sendMessage(Player player, SailsShipControl controller);
 
     @Override
-    public @Nullable CompoundTag onCopy(@NotNull ServerLevel serverLevel, @NotNull BlockPos blockPos, @NotNull BlockState blockState, @Nullable BlockEntity blockEntity, @NotNull List<? extends ServerShip> list, @NotNull Map<Long, ? extends Vector3d> map) {
+    public @Nullable CompoundTag onCopy(@NotNull ServerLevel serverLevel, @NotNull BlockPos blockPos, @NotNull BlockState blockState, @Nullable BlockEntity blockEntity, @NotNull List<? extends ServerShip> list, @NotNull Map<Long, ? extends Vector3dc> map) {
         return null;
     }
 
     @Override
-    public @Nullable CompoundTag onPaste(@NotNull ServerLevel serverLevel, @NotNull BlockPos blockPos, @NotNull BlockState blockState, @NotNull Map<Long, Long> map, @NotNull Map<Long, ? extends Pair<? extends Vector3d, ? extends Vector3d>> map1, @Nullable CompoundTag compoundTag) {
+    public @Nullable CompoundTag onPaste(@NotNull ServerLevel serverLevel, @NotNull BlockPos blockPos, @NotNull BlockState blockState, @NotNull Map<Long, Long> map, @NotNull Map<Long, ? extends Pair<? extends Vector3dc, ? extends Vector3dc>> map1, @Nullable CompoundTag compoundTag) {
         ServerShip serverShip = VSGameUtilsKt.getShipManagingPos(serverLevel, blockPos);
         if (serverShip == null) {
             return null;

--- a/common/src/main/java/com/quintonc/vs_sails/blocks/SailBlock.java
+++ b/common/src/main/java/com/quintonc/vs_sails/blocks/SailBlock.java
@@ -37,6 +37,7 @@ import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3d;
+import org.joml.Vector3dc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.valkyrienskies.core.api.ships.LoadedServerShip;
@@ -489,12 +490,12 @@ public class SailBlock extends Block implements ICopyableBlock {
     }
 
     @Override
-    public @Nullable CompoundTag onCopy(@NotNull ServerLevel serverLevel, @NotNull BlockPos blockPos, @NotNull BlockState blockState, @Nullable BlockEntity blockEntity, @NotNull List<? extends ServerShip> list, @NotNull Map<Long, ? extends Vector3d> map) {
+    public @Nullable CompoundTag onCopy(@NotNull ServerLevel serverLevel, @NotNull BlockPos blockPos, @NotNull BlockState blockState, @Nullable BlockEntity blockEntity, @NotNull List<? extends ServerShip> list, @NotNull Map<Long, ? extends Vector3dc> map) {
         return null;
     }
 
     @Override
-    public @Nullable CompoundTag onPaste(@NotNull ServerLevel serverLevel, @NotNull BlockPos blockPos, @NotNull BlockState blockState, @NotNull Map<Long, Long> map, @NotNull Map<Long, ? extends Pair<? extends Vector3d, ? extends Vector3d>> map1, @Nullable CompoundTag compoundTag) {
+    public @Nullable CompoundTag onPaste(@NotNull ServerLevel serverLevel, @NotNull BlockPos blockPos, @NotNull BlockState blockState, @NotNull Map<Long, Long> map, @NotNull Map<Long, ? extends Pair<? extends Vector3dc, ? extends Vector3dc>> map1, @Nullable CompoundTag compoundTag) {
         ServerShip serverShip = VSGameUtilsKt.getShipManagingPos(serverLevel, blockPos);
         if (serverShip == null) {
             return null;
@@ -508,5 +509,4 @@ public class SailBlock extends Block implements ICopyableBlock {
         });
         return null;
     }
-
 }

--- a/common/src/main/java/com/quintonc/vs_sails/blocks/WindFlagBlock.java
+++ b/common/src/main/java/com/quintonc/vs_sails/blocks/WindFlagBlock.java
@@ -128,11 +128,9 @@ public class WindFlagBlock extends BaseEntityBlock {
         BlockPos pos = context.getClickedPos();
         Level level = context.getLevel();
 
-        boolean basic_pole = context.getPlayer().isShiftKeyDown();
-
         BlockState standard = this.defaultBlockState()
                 .setValue(IS_TOP, true)
-                .setValue(IS_FLAG, !basic_pole)
+                .setValue(IS_FLAG, true)
                 .setValue(FLAG_GROUP, false)
                 .setValue(OVERLAY_ONLY, false)
                 .setValue(EMISSIVE, false)
@@ -143,7 +141,6 @@ public class WindFlagBlock extends BaseEntityBlock {
         if (
                 context.getPlayer().getMainHandItem().getCount() >= 2
                 && level.getBlockState(pos.above()).canBeReplaced()
-                && !basic_pole
                 && !(level.getBlockState(pos.below()).getBlock() instanceof WindFlagBlock)
         ) {
             level.setBlock(pos.above(), standard, 3);
@@ -182,6 +179,12 @@ public class WindFlagBlock extends BaseEntityBlock {
                         1.0f
                 );
             }
+            return InteractionResult.sidedSuccess(level.isClientSide);
+        }
+
+        if (heldItem.is(Items.SHEARS)) {
+            level.setBlock(pos, state.setValue(IS_FLAG, !state.getValue(IS_FLAG)), 3);
+
             return InteractionResult.sidedSuccess(level.isClientSide);
         }
 
@@ -298,7 +301,7 @@ public class WindFlagBlock extends BaseEntityBlock {
                             && state.getValue(OVERLAY_COLOR) == desiredOverlayColor
                             && state.getValue(EMISSIVE) == desiredEmissive
                             && state.getValue(FURLED) == desiredFurled;
-            if (sameBlockType && sameStateValues) {
+            if ((sameBlockType && sameStateValues) || player.isShiftKeyDown()) {
                 return InteractionResult.PASS;
             }
 

--- a/common/src/main/java/com/quintonc/vs_sails/blocks/WindFlagBlock.java
+++ b/common/src/main/java/com/quintonc/vs_sails/blocks/WindFlagBlock.java
@@ -1,6 +1,7 @@
 package com.quintonc.vs_sails.blocks;
 
 import com.quintonc.vs_sails.blocks.entity.WindFlagBlockEntity;
+import com.quintonc.vs_sails.util.ModTags;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -44,15 +45,38 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
+import java.util.*;
 
 public class WindFlagBlock extends BaseEntityBlock {
     //Blockstate properties used in rendering
+
+    /**
+     * Used to render the flag model from the blockstate file in the renderer. Should NOT be set from this class! (should be kept false)
+     */
     public static final BooleanProperty FLAG_GROUP = BooleanProperty.create("flag_group");
+
+    /**
+     * Used to render the overlay models from the blockstate file in the renderer. Should NOT be set from this class! (should be kept false)
+     */
     public static final BooleanProperty OVERLAY_ONLY = BooleanProperty.create("overlay_only");
+
     public static final BooleanProperty EMISSIVE = BooleanProperty.create("emissive");
+
+    /**
+     * Controls whether the flag is hidden, toggled by user clicking
+     */
     public static final BooleanProperty FURLED = BooleanProperty.create("furled");
-    public static final EnumProperty<DoubleBlockHalf> HALF = BlockStateProperties.DOUBLE_BLOCK_HALF;
+
+    /**
+     * Controls whether the pole (flag or not) has the top-knobby bit in the model
+     */
+    public static final BooleanProperty IS_TOP = BooleanProperty.create("is_top");
+
+    /**
+     * Controls whether the block should be handled by the flag renderer or not. If not a flag, it'll just be a plain pole.
+     */
+    public static final BooleanProperty IS_FLAG = BooleanProperty.create("is_flag");
+
     //Banner pattern currently displayed
     public static final IntegerProperty PATTERN = IntegerProperty.create("pattern", 0, 6);
     //Color of the banner pattern
@@ -85,60 +109,49 @@ public class WindFlagBlock extends BaseEntityBlock {
     public WindFlagBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(this.defaultBlockState()
+                .setValue(IS_FLAG, true)
                 .setValue(FLAG_GROUP, false)
                 .setValue(OVERLAY_ONLY, false)
                 .setValue(EMISSIVE, false)
                 .setValue(FURLED, false)
-                .setValue(HALF, DoubleBlockHalf.LOWER)
                 .setValue(PATTERN, PATTERN_NONE)
                 .setValue(OVERLAY_COLOR, DEFAULT_OVERLAY_COLOR));
     }
 
     @Override
     public RenderShape getRenderShape(BlockState state) {
-        if (state.getValue(HALF) == DoubleBlockHalf.UPPER) {
-            return RenderShape.INVISIBLE;
-        }
         return RenderShape.MODEL;
-    }
-
-    @Override
-    public @NotNull SoundType getSoundType(BlockState state) {
-        if (state.getValue(HALF) == DoubleBlockHalf.UPPER) {
-            return SoundType.EMPTY;
-        }
-        return super.getSoundType(state);
     }
 
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
         BlockPos pos = context.getClickedPos();
         Level level = context.getLevel();
-        if (pos.getY() >= level.getMaxBuildHeight() - 1) {
-            return null;
-        }
-        if (!level.getBlockState(pos.above()).canBeReplaced(context)) {
-            return null;
-        }
-        return this.defaultBlockState()
+
+        boolean basic_pole = context.getPlayer().isShiftKeyDown();
+
+        BlockState standard = this.defaultBlockState()
+                .setValue(IS_TOP, true)
+                .setValue(IS_FLAG, !basic_pole)
                 .setValue(FLAG_GROUP, false)
                 .setValue(OVERLAY_ONLY, false)
                 .setValue(EMISSIVE, false)
                 .setValue(FURLED, false)
-                .setValue(HALF, DoubleBlockHalf.LOWER)
                 .setValue(PATTERN, PATTERN_NONE)
                 .setValue(OVERLAY_COLOR, DEFAULT_OVERLAY_COLOR);
-    }
 
-    @Override
-    public void setPlacedBy(Level level, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
-        level.setBlock(
-                pos.above(),
-                state.setValue(HALF, DoubleBlockHalf.UPPER)
-                        .setValue(FLAG_GROUP, false)
-                        .setValue(OVERLAY_ONLY, false),
-                3
-        );
+        if (
+                context.getPlayer().getMainHandItem().getCount() >= 2
+                && level.getBlockState(pos.above()).canBeReplaced()
+                && !basic_pole
+                && !(level.getBlockState(pos.below()).getBlock() instanceof WindFlagBlock)
+        ) {
+            level.setBlock(pos.above(), standard, 3);
+            context.getPlayer().getMainHandItem().shrink(1);
+            return standard.setValue(IS_FLAG, false).setValue(IS_TOP, false);
+        }
+
+        return standard;
     }
 
     @Override
@@ -152,26 +165,17 @@ public class WindFlagBlock extends BaseEntityBlock {
     ) {
         ItemStack heldItem = player.getItemInHand(hand);
         int pattern = getPatternFromItem(heldItem);
-        BlockPos lowerPos = state.getValue(HALF) == DoubleBlockHalf.LOWER ? pos : pos.below();
-        BlockState lowerState = level.getBlockState(lowerPos);
-        if (!isWindFlagHalf(lowerState, DoubleBlockHalf.LOWER)) {
-            return InteractionResult.PASS;
-        }
 
         //Furling/Unfurling
         if (hand == InteractionHand.MAIN_HAND && heldItem.isEmpty()) {
-            boolean furled = !lowerState.getValue(FURLED);
+            boolean furled = !state.getValue(FURLED);
             if (!level.isClientSide) {
-                BlockPos upperPos = lowerPos.above();
-                BlockState upperState = level.getBlockState(upperPos);
 
-                level.setBlock(lowerPos, lowerState.setValue(FURLED, furled), 3);
-                if (isWindFlagHalf(upperState, DoubleBlockHalf.UPPER)) {
-                    level.setBlock(upperPos, upperState.setValue(FURLED, furled), 3);
-                }
+                setFurledChain(level, pos, furled);
+
                 level.playSound(
                         null,
-                        lowerPos,
+                        pos,
                         furled ? SoundEvents.BUNDLE_INSERT : SoundEvents.BUNDLE_DROP_CONTENTS,
                         SoundSource.BLOCKS,
                         1.0f,
@@ -183,19 +187,15 @@ public class WindFlagBlock extends BaseEntityBlock {
 
         //Jeb_ nametag rainbow mode
         if (isRainbowNameTag(heldItem)) {
-            if (lowerState.getValue(OVERLAY_COLOR) == OVERLAY_COLOR_RAINBOW) {
+            if (state.getValue(OVERLAY_COLOR) == OVERLAY_COLOR_RAINBOW) {
                 return InteractionResult.sidedSuccess(level.isClientSide);
             }
 
             if (!level.isClientSide) {
-                BlockPos upperPos = lowerPos.above();
-                BlockState upperState = level.getBlockState(upperPos);
 
-                level.setBlock(lowerPos, lowerState.setValue(OVERLAY_COLOR, OVERLAY_COLOR_RAINBOW), 3);
-                if (isWindFlagHalf(upperState, DoubleBlockHalf.UPPER)) {
-                    level.setBlock(upperPos, upperState.setValue(OVERLAY_COLOR, OVERLAY_COLOR_RAINBOW), 3);
-                }
-                level.playSound(null, lowerPos, SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT, SoundSource.BLOCKS, 1.0f, 1.0f);
+                level.setBlock(pos, state.setValue(OVERLAY_COLOR, OVERLAY_COLOR_RAINBOW), 3);
+
+                level.playSound(null, pos, SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT, SoundSource.BLOCKS, 1.0f, 1.0f);
 
                 if (!player.getAbilities().instabuild) {
                     heldItem.shrink(1);
@@ -207,22 +207,17 @@ public class WindFlagBlock extends BaseEntityBlock {
 
         //Emissive rendering with glow ink sac
         if (heldItem.is(Items.GLOW_INK_SAC)) {
-            if (lowerState.getValue(PATTERN) == PATTERN_NONE) {
+            if (state.getValue(PATTERN) == PATTERN_NONE) {
                 return InteractionResult.PASS;
             }
-            if (lowerState.getValue(EMISSIVE)) {
+            if (state.getValue(EMISSIVE)) {
                 return InteractionResult.sidedSuccess(level.isClientSide);
             }
 
             if (!level.isClientSide) {
-                BlockPos upperPos = lowerPos.above();
-                BlockState upperState = level.getBlockState(upperPos);
+                level.setBlock(pos, state.setValue(EMISSIVE, true), 3);
 
-                level.setBlock(lowerPos, lowerState.setValue(EMISSIVE, true), 3);
-                if (isWindFlagHalf(upperState, DoubleBlockHalf.UPPER)) {
-                    level.setBlock(upperPos, upperState.setValue(EMISSIVE, true), 3);
-                }
-                level.playSound(null, lowerPos, SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT, SoundSource.BLOCKS, 1.0f, 1.0f);
+                level.playSound(null, pos, SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT, SoundSource.BLOCKS, 1.0f, 1.0f);
 
                 if (!player.getAbilities().instabuild) {
                     heldItem.shrink(1);
@@ -230,6 +225,10 @@ public class WindFlagBlock extends BaseEntityBlock {
             }
 
             return InteractionResult.sidedSuccess(level.isClientSide);
+        }
+
+        if (!state.getValue(IS_FLAG)) {
+            return InteractionResult.PASS;
         }
 
         //Flag blockswap
@@ -293,14 +292,14 @@ public class WindFlagBlock extends BaseEntityBlock {
             desiredPattern = Mth.clamp(desiredPattern, PATTERN_NONE, PATTERN_PIGLIN);
             desiredOverlayColor = Mth.clamp(desiredOverlayColor, 0, OVERLAY_COLOR_RAINBOW);
 
-            boolean sameBlockType = lowerState.getBlock() == replacementFlagBlock;
+            boolean sameBlockType = state.getBlock() == replacementFlagBlock;
             boolean sameStateValues =
-                    lowerState.getValue(PATTERN) == desiredPattern
-                            && lowerState.getValue(OVERLAY_COLOR) == desiredOverlayColor
-                            && lowerState.getValue(EMISSIVE) == desiredEmissive
-                            && lowerState.getValue(FURLED) == desiredFurled;
+                    state.getValue(PATTERN) == desiredPattern
+                            && state.getValue(OVERLAY_COLOR) == desiredOverlayColor
+                            && state.getValue(EMISSIVE) == desiredEmissive
+                            && state.getValue(FURLED) == desiredFurled;
             if (sameBlockType && sameStateValues) {
-                return InteractionResult.sidedSuccess(level.isClientSide);
+                return InteractionResult.PASS;
             }
 
             if (!level.isClientSide) {
@@ -309,29 +308,18 @@ public class WindFlagBlock extends BaseEntityBlock {
                         .setValue(OVERLAY_ONLY, false)
                         .setValue(EMISSIVE, desiredEmissive)
                         .setValue(FURLED, desiredFurled)
-                        .setValue(HALF, DoubleBlockHalf.LOWER)
-                        .setValue(PATTERN, desiredPattern)
-                        .setValue(OVERLAY_COLOR, desiredOverlayColor);
-                BlockState replacementUpperState = replacementFlagBlock.defaultBlockState()
-                        .setValue(FLAG_GROUP, false)
-                        .setValue(OVERLAY_ONLY, false)
-                        .setValue(EMISSIVE, desiredEmissive)
-                        .setValue(FURLED, desiredFurled)
-                        .setValue(HALF, DoubleBlockHalf.UPPER)
                         .setValue(PATTERN, desiredPattern)
                         .setValue(OVERLAY_COLOR, desiredOverlayColor);
 
-                BlockPos upperPos = lowerPos.above();
-                level.setBlock(lowerPos, replacementLowerState, 3);
-                level.setBlock(upperPos, replacementUpperState, 3);
-                level.playSound(null, lowerPos, SoundEvents.WOOL_BREAK, SoundSource.BLOCKS, 1.0f, 1.0f);
+                level.setBlock(pos, replacementLowerState, 3);
+                level.playSound(null, pos, SoundEvents.WOOL_BREAK, SoundSource.BLOCKS, 1.0f, 1.0f);
 
                 if (!player.getAbilities().instabuild) {
                     heldItem.shrink(1);
 
-                    Item oldFlagItem = lowerState.getBlock().asItem();
+                    Item oldFlagItem = state.getBlock().asItem();
                     ItemStack returnedStack = new ItemStack(oldFlagItem);
-                    writeStateTagToItem(returnedStack, lowerState);
+                    writeStateTagToItem(returnedStack, state);
 
                     if (heldItem.isEmpty()) {
                         player.setItemInHand(hand, returnedStack);
@@ -346,19 +334,15 @@ public class WindFlagBlock extends BaseEntityBlock {
 
         //Setting banner patterns
         if (pattern != PATTERN_NONE) {
-            if (lowerState.getValue(PATTERN) == pattern) {
+            if (state.getValue(PATTERN) == pattern) {
                 return InteractionResult.sidedSuccess(level.isClientSide);
             }
 
             if (!level.isClientSide) {
-                BlockPos upperPos = lowerPos.above();
-                BlockState upperState = level.getBlockState(upperPos);
 
-                level.setBlock(lowerPos, lowerState.setValue(PATTERN, pattern), 3);
-                if (isWindFlagHalf(upperState, DoubleBlockHalf.UPPER)) {
-                    level.setBlock(upperPos, upperState.setValue(PATTERN, pattern), 3);
-                }
-                level.playSound(null, lowerPos, SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT, SoundSource.BLOCKS, 1.0f, 1.0f);
+                level.setBlock(pos, state.setValue(PATTERN, pattern), 3);
+
+                level.playSound(null, pos, SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT, SoundSource.BLOCKS, 1.0f, 1.0f);
             }
 
             return InteractionResult.sidedSuccess(level.isClientSide);
@@ -369,24 +353,20 @@ public class WindFlagBlock extends BaseEntityBlock {
         if (dyeColor == null) {
             return InteractionResult.PASS;
         }
-        if (lowerState.getValue(PATTERN) == PATTERN_NONE) {
+        if (state.getValue(PATTERN) == PATTERN_NONE) {
             return InteractionResult.PASS;
         }
 
         int overlayColor = dyeColor.getId();
-        if (lowerState.getValue(OVERLAY_COLOR) == overlayColor) {
+        if (state.getValue(OVERLAY_COLOR) == overlayColor) {
             return InteractionResult.sidedSuccess(level.isClientSide);
         }
 
         if (!level.isClientSide) {
-            BlockPos upperPos = lowerPos.above();
-            BlockState upperState = level.getBlockState(upperPos);
 
-            level.setBlock(lowerPos, lowerState.setValue(OVERLAY_COLOR, overlayColor), 3);
-            if (isWindFlagHalf(upperState, DoubleBlockHalf.UPPER)) {
-                level.setBlock(upperPos, upperState.setValue(OVERLAY_COLOR, overlayColor), 3);
-            }
-            level.playSound(null, lowerPos, SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT, SoundSource.BLOCKS, 1.0f, 1.0f);
+            level.setBlock(pos, state.setValue(OVERLAY_COLOR, overlayColor), 3);
+
+            level.playSound(null, pos, SoundEvents.UI_CARTOGRAPHY_TABLE_TAKE_RESULT, SoundSource.BLOCKS, 1.0f, 1.0f);
 
             if (!player.getAbilities().instabuild) {
                 heldItem.shrink(1);
@@ -396,14 +376,61 @@ public class WindFlagBlock extends BaseEntityBlock {
         return InteractionResult.sidedSuccess(level.isClientSide);
     }
 
+    // Slighlty vibe coded, I will admit.
+    public static void setFurledChain(Level level, BlockPos startPos, boolean furled) {
+        BlockState startState = level.getBlockState(startPos);
+
+        if (!(startState.getBlock() instanceof WindFlagBlock)) {
+            return;
+        }
+
+        Set<BlockPos> visited = new HashSet<>();
+        Queue<BlockPos> queue = new ArrayDeque<>();
+
+        queue.add(startPos);
+        visited.add(startPos);
+
+        while (!queue.isEmpty()) {
+            BlockPos pos = queue.poll();
+            BlockState state = level.getBlockState(pos);
+
+            if (!(state.getBlock() instanceof WindFlagBlock)) {
+                continue;
+            }
+
+            // Only update if needed (prevents redundant updates + loops)
+            if (state.getValue(WindFlagBlock.FURLED) != furled) {
+                level.setBlock(
+                        pos,
+                        state.setValue(WindFlagBlock.FURLED, furled),
+                        Block.UPDATE_CLIENTS // avoid excessive neighbor spam
+                );
+            }
+
+            // Check vertical neighbors only
+            BlockPos up = pos.above();
+            BlockPos down = pos.below();
+
+            if (!visited.contains(up) && level.getBlockState(up).getBlock() instanceof WindFlagBlock) {
+                queue.add(up);
+                visited.add(up);
+            }
+
+            if (!visited.contains(down) && level.getBlockState(down).getBlock() instanceof WindFlagBlock) {
+                queue.add(down);
+                visited.add(down);
+            }
+        }
+    }
+
     @Override
     public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
-        return state.getValue(HALF) == DoubleBlockHalf.LOWER ? LOWER_SHAPE : UPPER_SHAPE;
+        return state.getValue(IS_TOP) ? UPPER_SHAPE : LOWER_SHAPE;
     }
 
     @Override
     public VoxelShape getBlockSupportShape(BlockState state, BlockGetter level, BlockPos pos) {
-        return state.getValue(HALF) == DoubleBlockHalf.UPPER ? UPPER_TOPPER_SHAPE : LOWER_SHAPE;
+        return state.getValue(IS_TOP) ? UPPER_SHAPE : LOWER_SHAPE;
     }
 
     @Override
@@ -415,35 +442,26 @@ public class WindFlagBlock extends BaseEntityBlock {
             BlockPos currentPos,
             BlockPos neighborPos
     ) {
-        DoubleBlockHalf half = state.getValue(HALF);
-        if (direction.getAxis() == Direction.Axis.Y) {
-            if (half == DoubleBlockHalf.LOWER && direction == Direction.UP) {
-                if (!isWindFlagHalf(neighborState, DoubleBlockHalf.UPPER)) {
-                    return Blocks.AIR.defaultBlockState();
-                }
-            } else if (half == DoubleBlockHalf.UPPER && direction == Direction.DOWN) {
-                if (!isWindFlagHalf(neighborState, DoubleBlockHalf.LOWER)) {
-                    return Blocks.AIR.defaultBlockState();
-                }
-            }
+        if (level.getBlockState(currentPos.below()).isAir()) {
+            return Blocks.AIR.defaultBlockState();
         }
-        return super.updateShape(state, direction, neighborState, level, currentPos, neighborPos);
+
+        BlockState above = level.getBlockState(currentPos.above());
+        if (above.getBlock() instanceof WindFlagBlock) {
+            return state.setValue(IS_TOP, false);
+        } else {
+            return state.setValue(IS_TOP, true);
+        }
     }
 
     @Nullable
     @Override
     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
-        if (state.getValue(HALF) == DoubleBlockHalf.UPPER) {
-            return null;
-        }
         return new WindFlagBlockEntity(pos, state);
     }
 
     @Override
     public @NotNull List<ItemStack> getDrops(BlockState state, LootParams.Builder params) {
-        if (state.getValue(HALF) == DoubleBlockHalf.UPPER) {
-            return List.of();
-        }
         List<ItemStack> drops = super.getDrops(state, params);
         for (ItemStack drop : drops) {
             if (drop.getItem() instanceof BlockItem blockItem && blockItem.getBlock() == this) {
@@ -501,8 +519,8 @@ public class WindFlagBlock extends BaseEntityBlock {
 
     private static boolean isWindFlagHalf(BlockState state, DoubleBlockHalf expectedHalf) {
         return state.getBlock() instanceof WindFlagBlock
-                && state.hasProperty(HALF)
-                && state.getValue(HALF) == expectedHalf;
+                && state.hasProperty(IS_TOP)
+                && state.getValue(IS_TOP) == (expectedHalf == DoubleBlockHalf.UPPER);
     }
 
     public static int getOverlayTintColor(BlockState state, @Nullable BlockGetter level, @Nullable BlockPos pos, int tintIndex) {
@@ -613,6 +631,6 @@ public class WindFlagBlock extends BaseEntityBlock {
 
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
-        builder.add(FLAG_GROUP, OVERLAY_ONLY, EMISSIVE, FURLED, HALF, PATTERN, OVERLAY_COLOR);
+        builder.add(FLAG_GROUP, OVERLAY_ONLY, EMISSIVE, FURLED, IS_TOP, IS_FLAG, PATTERN, OVERLAY_COLOR);
     }
 }

--- a/common/src/main/java/com/quintonc/vs_sails/blocks/entity/renderer/WindFlagBlockEntityRenderer.java
+++ b/common/src/main/java/com/quintonc/vs_sails/blocks/entity/renderer/WindFlagBlockEntityRenderer.java
@@ -4,20 +4,30 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import com.quintonc.vs_sails.blocks.WindFlagBlock;
 import com.quintonc.vs_sails.blocks.entity.WindFlagBlockEntity;
+import com.quintonc.vs_sails.registration.SailsBlocks;
 import com.quintonc.vs_sails.wind.WindManager;
-import net.minecraft.client.renderer.LightTexture;
-import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.util.Mth;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Vector3d;
 import org.valkyrienskies.core.api.ships.ClientShip;
 import org.valkyrienskies.mod.common.VSGameUtilsKt;
+
+import static com.quintonc.vs_sails.blocks.WindFlagBlock.IS_TOP;
 
 public class WindFlagBlockEntityRenderer implements BlockEntityRenderer<WindFlagBlockEntity> {
     private static final float FLAG_PIVOT_X = 0.5f; //8.0f / 16.0f;
@@ -50,7 +60,8 @@ public class WindFlagBlockEntityRenderer implements BlockEntityRenderer<WindFlag
         }
 
         BlockState sourceState = entity.getBlockState();
-        if (sourceState.getValue(WindFlagBlock.FURLED)) {
+
+        if (sourceState.getValue(WindFlagBlock.FURLED) || !sourceState.getValue(WindFlagBlock.IS_FLAG)) {
             return;
         }
 
@@ -87,18 +98,24 @@ public class WindFlagBlockEntityRenderer implements BlockEntityRenderer<WindFlag
         poseStack.rotateAround(Axis.YP.rotationDegrees(-yawDegrees), FLAG_PIVOT_X, FLAG_PIVOT_Y, FLAG_PIVOT_Z);
         blockRenderDispatcher.renderSingleBlock(baseState, poseStack, bufferSource, packedLight, packedOverlay);
         if (hasOverlay) {
-            BlockState overlayState = sourceState
+            // TODO: Allow the blockstate files to override this without having to write out the overlays for every single one
+            BlockState overlayState = SailsBlocks.WIND_FLAG.get().defaultBlockState()
+                    .setValue(WindFlagBlock.PATTERN, sourceState.getValue(WindFlagBlock.PATTERN))
+                    .setValue(WindFlagBlock.OVERLAY_COLOR, sourceState.getValue(WindFlagBlock.OVERLAY_COLOR))
                     .setValue(WindFlagBlock.FLAG_GROUP, true)
                     .setValue(WindFlagBlock.OVERLAY_ONLY, true);
+
             int overlayLight = sourceState.getValue(WindFlagBlock.EMISSIVE) ? LightTexture.FULL_BRIGHT : packedLight;
             blockRenderDispatcher.renderSingleBlock(overlayState, poseStack, bufferSource, overlayLight, packedOverlay);
         }
         poseStack.popPose();
     }
 
-    //Technically, this is not good for performance.
-    //The value of having distant flag visibility (i.e. identifying approaching ships)
-    //supercedes the minimal perf benefit of a custom LOD solution.
+    /**
+     * Technically, this is not good for performance.
+     * But the value of having distant flag visibility (i.e. identifying approaching ships)
+     * supersedes the minimal perf benefit of a custom LOD solution.
+     */
     @Override
     public int getViewDistance() {
         return 320;

--- a/common/src/main/resources/assets/vs_sails/blockstates/black_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/black_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_black_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/blue_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/blue_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_blue_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/brown_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/brown_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_brown_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/cyan_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/cyan_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_cyan_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/gray_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/gray_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_gray_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/green_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/green_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_green_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/light_blue_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/light_blue_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_light_blue_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/light_gray_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/light_gray_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_light_gray_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/lime_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/lime_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_lime_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/magenta_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/magenta_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_magenta_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/orange_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/orange_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_orange_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/pink_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/pink_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_pink_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/purple_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/purple_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_purple_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/red_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/red_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_red_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/white_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/white_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_white_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/blockstates/wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,16 +12,16 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
@@ -30,8 +31,6 @@
     },
     {
       "when": {
-        "half": "lower",
-        "flag_group": "true",
         "overlay_only": "true",
         "pattern": "1"
       },
@@ -41,8 +40,6 @@
     },
     {
       "when": {
-        "half": "lower",
-        "flag_group": "true",
         "overlay_only": "true",
         "pattern": "2"
       },
@@ -52,8 +49,6 @@
     },
     {
       "when": {
-        "half": "lower",
-        "flag_group": "true",
         "overlay_only": "true",
         "pattern": "3"
       },
@@ -63,8 +58,6 @@
     },
     {
       "when": {
-        "half": "lower",
-        "flag_group": "true",
         "overlay_only": "true",
         "pattern": "4"
       },
@@ -74,8 +67,6 @@
     },
     {
       "when": {
-        "half": "lower",
-        "flag_group": "true",
         "overlay_only": "true",
         "pattern": "5"
       },
@@ -85,8 +76,6 @@
     },
     {
       "when": {
-        "half": "lower",
-        "flag_group": "true",
         "overlay_only": "true",
         "pattern": "6"
       },

--- a/common/src/main/resources/assets/vs_sails/blockstates/yellow_wind_flag.json
+++ b/common/src/main/resources/assets/vs_sails/blockstates/yellow_wind_flag.json
@@ -2,8 +2,9 @@
   "multipart": [
     {
       "when": {
-        "half": "lower",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "false",
+        "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag_pole"
@@ -11,87 +12,21 @@
     },
     {
       "when": {
-        "half": "upper",
-        "flag_group": "false"
+        "flag_group": "false",
+        "is_top": "true",
+        "overlay_only": "false"
       },
       "apply": {
-        "model": "vs_sails:block/wind_flag_pole"
+        "model": "vs_sails:block/pole_top"
       }
     },
     {
       "when": {
-        "half": "lower",
         "flag_group": "true",
         "overlay_only": "false"
       },
       "apply": {
         "model": "vs_sails:block/wind_flag/rotate_yellow_wind_flag"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "1"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_skull"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "2"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_creeper"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "3"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_flower"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "4"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_mojang"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "5"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_globe"
-      }
-    },
-    {
-      "when": {
-        "half": "lower",
-        "flag_group": "true",
-        "overlay_only": "true",
-        "pattern": "6"
-      },
-      "apply": {
-        "model": "vs_sails:block/wind_flag/rotate_overlay_piglin"
       }
     }
   ]

--- a/common/src/main/resources/assets/vs_sails/models/block/pole_top.json
+++ b/common/src/main/resources/assets/vs_sails/models/block/pole_top.json
@@ -1,0 +1,38 @@
+{
+	"format_version": "1.9.0",
+	"credit": "Made with Blockbench",
+	"textures": {
+		"3": "vs_sails:block/wind_flag_pole",
+		"particle": "vs_sails:block/wind_flag_pole"
+	},
+	"elements": [
+		{
+			"name": "topper",
+			"from": [6.7, 13.5, 6.75],
+			"to": [9.2, 16, 9.25],
+			"rotation": {"angle": 0, "axis": "y", "origin": [7, 29.5, 6.75]},
+			"faces": {
+				"north": {"uv": [1, 3, 2.25, 4.25], "texture": "#3"},
+				"east": {"uv": [1, 3, 2.25, 4.25], "texture": "#3"},
+				"south": {"uv": [1, 3, 2.25, 4.25], "texture": "#3"},
+				"west": {"uv": [1, 3, 2.25, 4.25], "texture": "#3"},
+				"up": {"uv": [3.5, 4.25, 2.25, 3], "texture": "#3"},
+				"down": {"uv": [2.25, 3, 1, 4.25], "texture": "#3"}
+			}
+		},
+		{
+			"name": "pole",
+			"from": [7, 0, 7],
+			"to": [9, 15.99, 9],
+			"rotation": {"angle": 0, "axis": "y", "origin": [7, 0, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 8], "texture": "#3"},
+				"east": {"uv": [0, 0, 1, 15.5], "texture": "#3"},
+				"south": {"uv": [0, 0, 1, 15.5], "texture": "#3"},
+				"west": {"uv": [0, 0, 1, 15.5], "texture": "#3"},
+				"up": {"uv": [4.25, 2, 3.25, 1], "texture": "#missing"},
+				"down": {"uv": [4.25, 1, 3.25, 2], "texture": "#missing"}
+			}
+		}
+	]
+}

--- a/common/src/main/resources/assets/vs_sails/models/block/wind_flag/rotate_base.json
+++ b/common/src/main/resources/assets/vs_sails/models/block/wind_flag/rotate_base.json
@@ -1,51 +1,51 @@
 {
-  "textures": {
-    "3": "#pole",
-    "4": "#flag",
-    "particle": "minecraft:block/stripped_spruce_log"
-  },
-  "elements": [
-    {
-      "name": "rope_1",
-      "from": [6.5, 27, 6.5],
-      "to": [11, 28, 9.5],
-      "rotation": {"angle": 0, "axis": "y", "origin": [8, 26, 8]},
-      "faces": {
-        "north": {"uv": [3.25, 0, 5.5, 0.5], "texture": "#3"},
-        "east": {"uv": [3.25, 2, 4.75, 2.5], "texture": "#3"},
-        "south": {"uv": [3.25, 0.5, 5.5, 1], "texture": "#3"},
-        "west": {"uv": [3.25, 2.5, 4.75, 3], "texture": "#3"},
-        "up": {"uv": [1, 0, 3.25, 1.5], "texture": "#3"},
-        "down": {"uv": [1, 1.5, 3.25, 3], "texture": "#3"}
-      }
+    "textures": {
+      "3": "#pole",
+      "4": "#flag",
+      "particle": "minecraft:block/stripped_spruce_log"
     },
-    {
-      "name": "rope_2",
-      "from": [6.5, 20, 6.5],
-      "to": [11, 21, 9.5],
-      "rotation": {"angle": 0, "axis": "y", "origin": [8, 26, 8]},
-      "faces": {
-        "north": {"uv": [3.25, 0, 5.5, 0.5], "texture": "#3"},
-        "east": {"uv": [3.25, 2, 4.75, 2.5], "texture": "#3"},
-        "south": {"uv": [3.25, 0.5, 5.5, 1], "texture": "#3"},
-        "west": {"uv": [3.25, 2.5, 4.75, 3], "texture": "#3"},
-        "up": {"uv": [3.25, 1.5, 1, 0], "texture": "#3"},
-        "down": {"uv": [3.25, 1.5, 1, 3], "texture": "#3"}
-      }
-    },
-    {
-      "name": "flag",
-      "from": [9.5, 18, 7.5],
-      "to": [31, 30, 8.5],
-      "rotation": {"angle": 0, "axis": "y", "origin": [8, 26, 8]},
-      "faces": {
-        "north": {"uv": [0, 2, 16, 11], "texture": "#4"},
-        "east": {"uv": [0, 1, 6, 1.5], "rotation": 90, "texture": "#4"},
-        "south": {"uv": [16, 2, 0, 11], "texture": "#4"},
-        "west": {"uv": [0, 1, 6, 1.5], "rotation": 90, "texture": "#4"},
-        "up": {"uv": [0, 1.5, 8, 2], "texture": "#4"},
-        "down": {"uv": [0, 1.5, 8, 2], "texture": "#4"}
-      }
-    }
-  ]
+	"elements": [
+		{
+			"name": "rope_1",
+			"from": [6.5, 11, 6.5],
+			"to": [11, 12, 9.5],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 26, 8]},
+			"faces": {
+				"north": {"uv": [3.25, 0, 5.5, 0.5], "texture": "#3"},
+				"east": {"uv": [3.25, 2, 4.75, 2.5], "texture": "#3"},
+				"south": {"uv": [3.25, 0.5, 5.5, 1], "texture": "#3"},
+				"west": {"uv": [3.25, 2.5, 4.75, 3], "texture": "#3"},
+				"up": {"uv": [1, 0, 3.25, 1.5], "texture": "#3"},
+				"down": {"uv": [1, 1.5, 3.25, 3], "texture": "#3"}
+			}
+		},
+		{
+			"name": "rope_2",
+			"from": [6.5, 4, 6.5],
+			"to": [11, 5, 9.5],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 26, 8]},
+			"faces": {
+				"north": {"uv": [3.25, 0, 5.5, 0.5], "texture": "#3"},
+				"east": {"uv": [3.25, 2, 4.75, 2.5], "texture": "#3"},
+				"south": {"uv": [3.25, 0.5, 5.5, 1], "texture": "#3"},
+				"west": {"uv": [3.25, 2.5, 4.75, 3], "texture": "#3"},
+				"up": {"uv": [3.25, 1.5, 1, 0], "texture": "#3"},
+				"down": {"uv": [3.25, 1.5, 1, 3], "texture": "#3"}
+			}
+		},
+		{
+			"name": "flag",
+			"from": [9.5, 2, 7.5],
+			"to": [31, 14, 8.5],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 26, 8]},
+			"faces": {
+				"north": {"uv": [0, 2, 16, 11], "texture": "#4"},
+				"east": {"uv": [0, 1, 6, 1.5], "rotation": 90, "texture": "#4"},
+				"south": {"uv": [16, 2, 0, 11], "texture": "#4"},
+				"west": {"uv": [0, 1, 6, 1.5], "rotation": 90, "texture": "#4"},
+				"up": {"uv": [0, 1.5, 8, 2], "texture": "#4"},
+				"down": {"uv": [0, 1.5, 8, 2], "texture": "#4"}
+			}
+		}
+	]
 }

--- a/common/src/main/resources/assets/vs_sails/models/block/wind_flag/rotate_overlay_base.json
+++ b/common/src/main/resources/assets/vs_sails/models/block/wind_flag/rotate_overlay_base.json
@@ -7,8 +7,8 @@
   "elements": [
     {
       "name": "overlay",
-      "from": [9.5, 18, 7.49],
-      "to": [31, 30, 8.51],
+      "from": [9.5, 2, 7.49],
+      "to": [31, 14, 8.51],
       "rotation": {
         "angle": 0,
         "axis": "y",

--- a/common/src/main/resources/assets/vs_sails/models/block/wind_flag_pole.json
+++ b/common/src/main/resources/assets/vs_sails/models/block/wind_flag_pole.json
@@ -1,37 +1,24 @@
 {
-  "textures": {
-    "3": "vs_sails:block/wind_flag_pole",
-    "4": "vs_sails:block/wind_flag",
-    "particle": "minecraft:block/stripped_spruce_log"
-  },
-  "elements": [
-    {
-      "name": "pole",
-      "from": [7, 0, 7],
-      "to": [9, 31, 9],
-      "rotation": {"angle": 0, "axis": "y", "origin": [7, 0, 7]},
-      "faces": {
-        "north": {"uv": [0, 0, 1, 15.5], "texture": "#3"},
-        "east": {"uv": [0, 0, 1, 15.5], "texture": "#3"},
-        "south": {"uv": [0, 0, 1, 15.5], "texture": "#3"},
-        "west": {"uv": [0, 0, 1, 15.5], "texture": "#3"},
-        "up": {"uv": [4.25, 2, 3.25, 1], "texture": "#3"},
-        "down": {"uv": [4.25, 1, 3.25, 2], "texture": "#3"}
-      }
-    },
-    {
-      "name": "topper",
-      "from": [6.7, 29.5, 6.75],
-      "to": [9.2, 32, 9.25],
-      "rotation": {"angle": 0, "axis": "y", "origin": [7, 29.5, 6.75]},
-      "faces": {
-        "north": {"uv": [1, 3, 2.25, 4.25], "texture": "#3"},
-        "east": {"uv": [1, 3, 2.25, 4.25], "texture": "#3"},
-        "south": {"uv": [1, 3, 2.25, 4.25], "texture": "#3"},
-        "west": {"uv": [1, 3, 2.25, 4.25], "texture": "#3"},
-        "up": {"uv": [3.5, 4.25, 2.25, 3], "texture": "#3"},
-        "down": {"uv": [2.25, 3, 1, 4.25], "texture": "#3"}
-      }
-    }
-  ]
+	"format_version": "1.9.0",
+	"credit": "Made with Blockbench",
+	"textures": {
+		"3": "vs_sails:block/wind_flag_pole",
+		"particle": "block/stripped_spruce_log"
+	},
+	"elements": [
+		{
+			"name": "pole",
+			"from": [7, 0, 7],
+			"to": [9, 16, 9],
+			"rotation": {"angle": 0, "axis": "y", "origin": [7, 0, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 1, 8], "texture": "#3"},
+				"east": {"uv": [0, 0, 1, 15.5], "texture": "#3"},
+				"south": {"uv": [0, 0, 1, 15.5], "texture": "#3"},
+				"west": {"uv": [0, 0, 1, 15.5], "texture": "#3"},
+				"up": {"uv": [4.25, 2, 3.25, 1], "texture": "#3"},
+				"down": {"uv": [4.25, 1, 3.25, 2], "texture": "#3"}
+			}
+		}
+	]
 }

--- a/common/src/main/resources/data/vs_sails/vs_mass/vs_sails.json
+++ b/common/src/main/resources/data/vs_sails/vs_mass/vs_sails.json
@@ -318,5 +318,73 @@
   {
     "block": "vs_sails:rope_block",
     "mass": 0.1
+  },
+  {
+    "block": "vs_sails:black_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:blue_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:brown_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:cyan_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:gray_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:green_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:light_blue_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:light_gray_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:lime_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:magenta_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:orange_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:pink_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:purple_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:red_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:white_wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:wind_flag",
+    "mass": 0.1
+  },
+  {
+    "block": "vs_sails:yellow_wind_flag",
+    "mass": 0.1
   }
 ]


### PR DESCRIPTION
Makes each wind flag self contained, no longer part of a two-block "multiblock" of sorts. This means flags can be stacked, made shorter, or taller. Shift-placing will place an "inactive" flag pole that won't have a flag even when unfurled, useful for decoration.

<img width="1918" height="1047" alt="image" src="https://github.com/user-attachments/assets/7d3e5ff5-2b86-41eb-b2af-4fc93a9ca518" />
